### PR TITLE
fix: togglから取得する記録が、日付指定した1日となるように調整

### DIFF
--- a/lib/Toggl.php
+++ b/lib/Toggl.php
@@ -165,7 +165,7 @@ class Toggl
         echo getColorLog("Togglから記録を取得しています。この処理には少し時間がかかるのでお待ちください" . PHP_EOL, 'notice');
 
         $startDate = date('Y-m-d', strtotime($date));
-        $endDate = date('Y-m-d', strtotime($date . ' +1 day'));
+        $endDate = $startDate;
 
         $url = "https://api.track.toggl.com/reports/api/v3/workspace/$this->workspaceId/search/time_entries";
 


### PR DESCRIPTION
日付指定した際に、翌日分の記録まで合わせて取得していたため